### PR TITLE
Add patch to disable LPO panic in AirPortBrcmNIC

### DIFF
--- a/AirportBrcmFixup/kern_brcmfx.cpp
+++ b/AirportBrcmFixup/kern_brcmfx.cpp
@@ -41,12 +41,12 @@ bool BRCMFX::init()
                                                callbackPatcher = &patcher;
                                                callbackBRCMFX->processKext(patcher, index, address, size);
                                            }, this);
-    
+
     if (error != LiluAPI::Error::NoError) {
         SYSLOG("BRCMFX", "failed to register onKextLoad method %d", error);
         return false;
     }
-    
+
 	return true;
 }
 
@@ -89,13 +89,13 @@ int64_t BRCMFX::wlc_set_countrycode_rev(int64_t a1, const char *country_code, in
 			new_country_code = callbackBRCMFX->provider_country_code;
 			DBGLOG("BRCMFX", "country code is overrided in ioreg");
         }
-        
+
         a3 = -1;
         result = callbackBRCMFX->orgWlcSetCountryCodeRev(a1, new_country_code, a3);
         DBGLOG("BRCMFX", "country code is changed from %s to %s, result = %lld", country_code, new_country_code, result);
         IOSleep(100);
     }
-    
+
     return result;
 }
 
@@ -113,15 +113,15 @@ bool BRCMFX::start(IOService* service, IOService* provider)
 {
     bool result = false;
     DBGLOG("BRCMFX", "start is called, service name is %s, provider name is %s", service->getName(), provider->getName());
-	
+
 	if (callbackBRCMFX && callbackPatcher)
 	{
 		if (callbackBRCMFX->wl_msg_level && ADDPR(brcmfx_config).wl_msg_level != 0)
 			*callbackBRCMFX->wl_msg_level = ADDPR(brcmfx_config).wl_msg_level;
-		
+
 		if (callbackBRCMFX->wl_msg_level2 && ADDPR(brcmfx_config).wl_msg_level2 != 0)
 			*callbackBRCMFX->wl_msg_level2 = ADDPR(brcmfx_config).wl_msg_level2;
-		
+
 		auto data = OSDynamicCast(OSData, provider->getProperty(ADDPR(brcmfx_config).bootargBrcmCountry));
 		if (data)
 		{
@@ -132,7 +132,7 @@ bool BRCMFX::start(IOService* service, IOService* provider)
 		if (callbackPatcher && callbackBRCMFX->orgStart)
 			result = callbackBRCMFX->orgStart(service, provider);
 	}
-    
+
     return result;
 }
 
@@ -161,7 +161,7 @@ IOService* findService(const IORegistryPlane* plane, const char *service_name)
     IOService            * service = 0;
     IORegistryIterator   * iter = IORegistryIterator::iterateOver(plane, kIORegistryIterateRecursively);
     OSOrderedSet         * all = 0;
-    
+
     if ( iter)
     {
         do
@@ -172,7 +172,7 @@ IOService* findService(const IORegistryPlane* plane, const char *service_name)
         }
         while (!iter->isValid());
         iter->release();
-        
+
         if (all)
         {
             while ((service = OSDynamicCast(IOService, all->getFirstObject())))
@@ -181,11 +181,11 @@ IOService* findService(const IORegistryPlane* plane, const char *service_name)
                 if (strcmp(service->getName(), service_name) == 0)
                     break;
             }
-            
+
             all->release();
         }
     }
-    
+
     return service;
 }
 
@@ -207,7 +207,7 @@ IOService* findService(const IORegistryPlane* plane, const char *service_name)
 // - restore rcx and rdi
 // - set the stored value at [rdi+0x3c]
 // - return to the caller (_wlc_proxd_attach or _pdburst_collection)
- 
+
  Assembler wrapper for calling _si_pmu_fvco_pllreg:
  00000000000000 57                     push       rdi                       // entry point, when _wlc_proxd_attach calls _si_pmu_fvco_pllreg, we are here
  00000000000001 8B4F3C                 mov        ecx, dword [rdi+0x3c]
@@ -248,11 +248,11 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
         if (kextList[i].loadIndex == index && !kext_handled[i])
         {
             kext_handled[i] = true;
-            
+
             while (true)
             {
                 DBGLOG("BRCMFX", "found %s", idList[i]);
-                
+
                 // IOServicePlane should keep a pointer to broadcom driver only if it was successfully started
                 IOService* running_service = findService(gIOServicePlane, serviceNameList[i]);
                 if (running_service != nullptr)
@@ -260,7 +260,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                     SYSLOG("BRCMFX", "%s driver is already loaded, too late to do patching", serviceNameList[i]);
                     break;
                 }
-                
+
                 // Failed PCIe configuration (device-id checking)
                 const char *method_name = symbolList[i][0];
                 auto method_address = patcher.solveSymbol(index, method_name, address, size);
@@ -276,7 +276,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                         if (probe_method_address)
                             patcher.routeFunction(probe_method_address, reinterpret_cast<mach_vm_address_t>(probe_mfg));
                     }
-                        
+
                     if (patcher.getError() == KernelPatcher::Error::NoError) {
                         DBGLOG("BRCMFX", "routed %s", method_name);
                     } else {
@@ -285,7 +285,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                 } else {
                     SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                 }
-                
+
                 if (i != 0)
                 {
                     // Chip identificator checking patch
@@ -303,7 +303,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                     } else {
                         SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                     }
-                    
+
                     // Wi-Fi 5 Ghz/Country code patch (required for 10.11)
                     method_name = symbolList[i][2];
                     method_address = patcher.solveSymbol(index, method_name, address, size);
@@ -319,7 +319,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                     } else {
                         SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                     }
-                    
+
                     // Third party device patch
                     method_name = symbolList[i][3];
                     method_address = patcher.solveSymbol(index, method_name, address, size);
@@ -335,7 +335,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                     } else {
                         SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                     }
-                    
+
                     // White list restriction patch
                     method_name = symbolList[i][4];
                     method_address = patcher.solveSymbol(index, method_name, address, size);
@@ -351,7 +351,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                     } else {
                         SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                     }
-                    
+
                     // Disable WOWL (WoWLAN)
                     if (!ADDPR(brcmfx_config).enable_wowl)
                     {
@@ -370,32 +370,48 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
                             SYSLOG("BRCMFX", "failed to resolve %s", method_name);
                         }
                     }
-                    
+
                     wl_msg_level = reinterpret_cast<int32_t *>(patcher.solveSymbol(index, "_wl_msg_level", address, size));
                     wl_msg_level2 = reinterpret_cast<int32_t *>(patcher.solveSymbol(index, "_wl_msg_level2", address, size));
                 }
-                
+
+                // Disable "32KHz LPO Clock not running" panic in AirPortBrcmNIC
+                if (i == 2)
+                {
+                    uint8_t find[]    = {0x25, 0x00, 0x31, 0xC0, 0xE8};
+                    uint8_t replace[] = {0x25, 0x00, 0xEB, 0x05, 0xE8};
+                    KernelPatcher::LookupPatch patch {
+                        &kextList[2], find, replace, sizeof(find), 1
+                    };
+
+                    patcher.applyLookupPatch(&patch);
+                    if (patcher.getError() != KernelPatcher::Error::NoError) {
+                        SYSLOG("BRCMFX", "failed to apply LPO panic patch %d", patcher.getError());
+                        patcher.clearError();
+                    }
+                }
+
                 ADDPR(brcmfx_config).disabled = true;
-                
-                IOService *service  = findService(gIOServicePlane,"FakeBrcm");
+
+                IOService *service = findService(gIOServicePlane, "FakeBrcm");
                 if (service && service->getProvider() != nullptr)
                 {
                     auto bundle  = OSDynamicCast(OSString, service->getProperty(kCFBundleIdentifierKey));
                     auto ioclass = OSDynamicCast(OSString, service->getProperty(KIOClass));
                     bundle  = bundle  ? bundle->withString(bundle)   : nullptr;
                     ioclass = ioclass ? ioclass->withString(ioclass) : nullptr;
-                    
+
                     IOService *provider = service->getProvider();
                     service->stop(provider);
                     bool success = service->terminate();
                     DBGLOG("BRCMFX", "terminating FakeBrcm with status %d", success);
-                    
+
                     if (provider->isOpen(service))
                     {
                         provider->close(service);
                         DBGLOG("BRCMFX", "FakeBrcm was closed");
                     }
-                    
+
                     if (success && bundle && ioclass)
                     {
                         OSDictionary * dict = OSDictionary::withCapacity(2);
@@ -423,7 +439,7 @@ void BRCMFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t
             }
         }
     }
-    
+
     // Ignore all the errors for other processors
     patcher.clearError();
 }

--- a/AirportBrcmFixup/kern_brcmfx.hpp
+++ b/AirportBrcmFixup/kern_brcmfx.hpp
@@ -15,7 +15,7 @@ class BRCMFX {
 public:
 	bool init();
 	void deinit();
-	
+
 private:
 
     /**
@@ -27,7 +27,7 @@ private:
      *  @param size    kinfo memory size
      */
     void processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
-    
+
     /**
      *  start func type
      */
@@ -37,11 +37,11 @@ private:
      *  wlc_set_countrycode_rev func type
      */
     using t_wlc_set_countrycode_rev = int64_t (*) (int64_t a1, const char *country_code, int a3);
-    
-    
-	/**
-	 *  Hooked methods / callbacks
-	 */
+
+
+    /**
+     *  Hooked methods / callbacks
+     */
     static bool             start(IOService *service, IOService* provider);
     static bool             start_mfg(IOService *service, IOService* provider);
     static IOService*       probe_mfg(IOService *service, IOService * provider, SInt32 *score);
@@ -50,7 +50,7 @@ private:
     static int64_t          wlc_set_countrycode_rev(int64_t a1, const char *country_code, int a3);
     static bool             wlc_wowl_enable(int64_t **a1);
 
-    
+
     /**
      *  Trampolines for original method invocations
      */
@@ -58,7 +58,7 @@ private:
     t_wlc_set_countrycode_rev   orgWlcSetCountryCodeRev     {nullptr};
     int32_t*                    wl_msg_level                {nullptr};
     int32_t*                    wl_msg_level2               {nullptr};
-	char 						provider_country_code[5] 	{""};
+    char                        provider_country_code[5]    {""};
 };
 
 #endif /* kern_brcmfx_hpp */

--- a/AirportBrcmFixup/kern_misc.hpp
+++ b/AirportBrcmFixup/kern_misc.hpp
@@ -33,9 +33,9 @@ static const char *symbolList[][6] {
     {"__ZN19AirPort_BrcmNIC_MFG5startEP9IOService", "_si_pmu_fvco_pllreg",  "_wlc_set_countrycode_rev",  "__ZNK19AirPort_BrcmNIC_MFG15newVendorStringEv",
      "__ZN19AirPort_BrcmNIC_MFG12checkBoardIdEPKc", "_wlc_wowl_enable" },
     {"__ZN16AirPort_Brcm43605startEP9IOService",    "_si_pmu_fvco_pllreg",  "_wlc_set_countrycode_rev",  "__ZNK16AirPort_Brcm436015newVendorStringEv",
-     "__ZN16AirPort_Brcm436012checkBoardIdEPKc",    "_wlc_wowl_enable"    },
+     "__ZN16AirPort_Brcm436012checkBoardIdEPKc",    "_wlc_wowl_enable" },
     {"__ZN15AirPort_BrcmNIC5startEP9IOService",     "_si_pmu_fvco_pllreg",  "_wlc_set_countrycode_rev",  "__ZNK15AirPort_BrcmNIC15newVendorStringEv",
-     "__ZN15AirPort_BrcmNIC12checkBoardIdEPKc" ,    "_wlc_wowl_enable"    }
+     "__ZN15AirPort_BrcmNIC12checkBoardIdEPKc" ,    "_wlc_wowl_enable" }
 };
 
 #endif /* kern_misc_hpp */


### PR DESCRIPTION
On some cards (DW1820A/BCM4350), the external LPO clock is sometimes
not set upon initialization. While harmless in AirPortBrcm4360,
AirPortBrcmNIC panics if this occurs. As it wasn't present previously,
add a patch to remove the call to _osl_panic in AirPortBrcmNIC.