### PR TITLE
Change BCM4352 driver from Brcm4360 to BrcmNIC

### DIFF
--- a/AirportBrcmFixup/Info.plist
+++ b/AirportBrcmFixup/Info.plist
@@ -35,6 +35,7 @@
 				<string>pci14e4,43ba</string>
 				<string>pci14e4,43a3</string>
 				<string>pci14e4,43a0</string>
+				<string>pci14e4,43b1</string>
 			</array>
 			<key>IOProbeScore</key>
 			<integer>1241</integer>
@@ -56,7 +57,6 @@
 				<string>pci14e4,4331</string>
 				<string>pci14e4,4353</string>
 				<string>pci14e4,4357</string>
-				<string>pci14e4,43b1</string>
 				<string>pci14e4,43b2</string>
 			</array>
 			<key>IOProbeScore</key>


### PR DESCRIPTION
Azurewave AW-CE123H (BCM94352HMB) and others work stable and are fully functional under BrcmNIC driver.
Using of newer AirPortBrcmNIC driver instead of AirPortBrcm4360 may improve performance and stability.