### PR TITLE
Add support for DW1820A CN-096JNT & Fix freezing issues

### DIFF
--- a/AirportBrcmFixup/Info.plist
+++ b/AirportBrcmFixup/Info.plist
@@ -33,7 +33,6 @@
 			<key>IONameMatch</key>
 			<array>
 				<string>pci14e4,43ba</string>
-				<string>pci14e4,43a3</string>
 				<string>pci14e4,43a0</string>
 				<string>pci14e4,43b1</string>
 				<string>pci14e4,43b2</string>
@@ -58,6 +57,7 @@
 				<string>pci14e4,4331</string>
 				<string>pci14e4,4353</string>
 				<string>pci14e4,4357</string>
+				<string>pci14e4,43a3</string>
 				<string>pci14e4,43b1</string>
 				<string>pci14e4,43b2</string>
 			</array>

--- a/AirportBrcmFixup/Info.plist
+++ b/AirportBrcmFixup/Info.plist
@@ -33,6 +33,7 @@
 			<key>IONameMatch</key>
 			<array>
 				<string>pci14e4,43ba</string>
+				<string>pci14e4,43a3</string>
 				<string>pci14e4,43a0</string>
 				<string>pci14e4,43b1</string>
 				<string>pci14e4,43b2</string>


### PR DESCRIPTION
I have recently purchased a DW1820A card as a cheaper alternative to DW1560 and DW1830 cards.
Looking at different forums i saw that a lot of people have issues like freezes,  panics,  etc.
Some ID(s) work fine,  some cause such issues. 
Mine was no exception, system was freezing all the time no matter what method i tried.

Before giving up i tried one more thing:
Add the ID(s) to Airport_Brcm4360 driver and boot with boot-arg: brcmfx-driver=1 and system booted fine, everything seems to be working fine,  been using it for almost a week and it's working like charm. 

This fixes freezing issues/adds support for **DW1820A CN-096JNT** model by using Airport_Brcm4360 driver instead of Airport_BrcmNIC via boot-arg: **brcmfx-driver=1**

- No FakePCIID.kext + Broadcom_WiFi.kext needed anymore
- No need for config.plist /Devices/Properties = injecting fake id(s)
- No need to change ASPM=0 with config.plist /Devices/Properties = pci-aspm-default=0
- No need to Pin mask any of the card connectors
- **You only need AirportBrcmFixup.kext + boot-arg: brcmfx-driver=1**

**Note:** This should add support & fix all the problems with other DW1820A models as well like:
**CN-0VW3T3** and **CN-08PKF4**